### PR TITLE
fix: 修正typeDefs與resolvers的路徑載入方式 (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 這是使用Apollo v4版本的Mahudas plugin。
 
 ## Dependencies
-+ mahudas^0.0.3
-+ @apollo/server^4.1.1
++ mahudas^0.0.7
++ @apollo/server^4.2.2
 + @graphql-tools/load-files^6.6.1
-+ @graphql-tools/merge^8.3.12
++ @graphql-tools/merge^8.3.14
 + dataloader^2.1.0
 
 ## 使用

--- a/lib/apollo_server.js
+++ b/lib/apollo_server.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs');
 const { ApolloServer } = require('@apollo/server');
 const { ApolloServerPluginDrainHttpServer } = require('@apollo/server/plugin/drainHttpServer');
 const { ApolloServerPluginLandingPageLocalDefault } = require('@apollo/server/plugin/landingPage/default');
@@ -29,7 +30,10 @@ module.exports = async (app) => {
       if (!config.typeDefsDir) {
         throw new Error('Apollo Error: typeDefs must be provided.');
       }
-      const defPath = path.resolve(config.typeDefsDir);
+      // 先去判斷config.typeDefsDir是否真的有這個目錄
+      // 如果沒有，就加上app.appInfo.root去尋找
+      let defPath = path.resolve(config.typeDefsDir);
+      if (!fs.existsSync(defPath)) defPath = path.join(app.appInfo.root, config.typeDefsDir);
       const typesArray = loadFilesSync(defPath, { recursive: true });
       const typeDefs = mergeTypeDefs(typesArray);
       options.typeDefs = typeDefs;
@@ -38,7 +42,10 @@ module.exports = async (app) => {
       if (!config.resolversDir) {
         console.log('\x1b[31m[apollo] %s\x1b[0m', 'WARNING: resolvers not defiined.');
       } else {
-        const resolverPath = path.resolve(config.resolversDir);
+        // 先去判斷config.typeDefsDir是否真的有這個目錄
+        // 如果沒有，就加上app.appInfo.root去尋找
+        let resolverPath = path.resolve(config.resolversDir);
+        if (!fs.existsSync(resolverPath)) resolverPath = path.join(app.appInfo.root, config.resolversDir);
         const resolversArray = loadFilesSync(resolverPath, { recursive: true });
         const resolvers = mergeResolvers(resolversArray);
         options.resolvers = resolvers;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
-        "@apollo/server": "^4.1.1",
+        "@apollo/server": "^4.2.2",
         "@graphql-tools/load-files": "^6.6.1",
-        "@graphql-tools/merge": "^8.3.12",
+        "@graphql-tools/merge": "^8.3.14",
         "dataloader": "^2.1.0",
-        "mahudas": "^0.0.3"
+        "mahudas": "^0.0.7"
       },
       "devDependencies": {
         "eslint": "^8.26.0",
@@ -69,20 +69,20 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.1.1.tgz",
-      "integrity": "sha512-YD4LktN4s4biNP6CzJ6vl+NCeeoAX5mVpwfl1oyPHXRpjJpgitGmTlkbv3U/pzBweZd3rMEEz30hex/ezsYKpg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.2.2.tgz",
+      "integrity": "sha512-kcWnRy63KFrY1SxIVGX56wlMLRSgwmn2qR0IG0A7Mvrl6oXijVP5ETj7ulmwRcvvJsIoDOObhcCW5hW3UZy41Q==",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/server-gateway-interface": "^1.0.5",
+        "@apollo/server-gateway-interface": "^1.0.7",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
-        "@apollo/utils.createhash": "^1.1.0",
-        "@apollo/utils.fetcher": "^1.0.0",
-        "@apollo/utils.isnodelike": "^1.1.0",
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "@apollo/utils.logger": "^1.0.0",
-        "@apollo/utils.usagereporting": "^1.0.0",
-        "@apollo/utils.withrequired": "^1.0.0",
+        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.fetcher": "^2.0.0",
+        "@apollo/utils.isnodelike": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.logger": "^2.0.0",
+        "@apollo/utils.usagereporting": "^2.0.0",
+        "@apollo/utils.withrequired": "^2.0.0",
         "@graphql-tools/schema": "^9.0.0",
         "@josephg/resolvable": "^1.0.0",
         "@types/express": "^4.17.13",
@@ -108,17 +108,14 @@
       }
     },
     "node_modules/@apollo/server-gateway-interface": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.5.tgz",
-      "integrity": "sha512-sAu85MR82hdccGW08+QwXAGKRL3LpOnc0DNleTSDMkC9+Uv1f841HviKk8YaWYkXzbWIKzS7YDsNLYlHG8G+XQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.7.tgz",
+      "integrity": "sha512-Eas36z851D0B0Hw8Ihpig2thHcoVAcFE7/I0+DAOaXr70r8kajPq5QHhngqFrlSTVl4AlJ7Yw1SGaWdvuSmDPQ==",
       "dependencies": {
         "@apollo/usage-reporting-protobuf": "^4.0.0",
-        "@apollo/utils.fetcher": "^1.0.0",
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "@apollo/utils.logger": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
+        "@apollo/utils.fetcher": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.logger": "^2.0.0"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
@@ -133,125 +130,137 @@
       }
     },
     "node_modules/@apollo/utils.createhash": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-1.1.0.tgz",
-      "integrity": "sha512-5fT4ZiW75515OlikWpIQzaVDws1yy9VgYSoHoJCrvI2UH6/7YNKXQjbjT5qVYu6ytch2wBxFMfFfYWMn/2bSCQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.0.tgz",
+      "integrity": "sha512-9GhGGD3J0HJF/VC+odwYpKi3Cg1NWrsO8GQvyGwDS5v/78I3154Hn8s4tpW+nqoaQ/lAvxdQQr3HM1b5HLM6Ww==",
       "dependencies": {
-        "@apollo/utils.isnodelike": "^1.1.0",
+        "@apollo/utils.isnodelike": "^2.0.0",
         "sha.js": "^2.4.11"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       }
     },
     "node_modules/@apollo/utils.dropunuseddefinitions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz",
-      "integrity": "sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.0.tgz",
+      "integrity": "sha512-BoPW+Z3kA8kLh0FCWyzOt+R77W5mVZWer5s6UyvVwZ/qROGiEgcHXFcI5TMMndpXoDo0xBSvQV0lIKYHbJQ7+g==",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/utils.fetcher": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-1.1.1.tgz",
-      "integrity": "sha512-0vXVznO7kw5VWwxyV5wsDvYEwjDpyZ7vYQAXCseLXqBn2eWEIDViM7qRzi/Hnv4zzAQ05phdimSED99K+lg+SQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.0.tgz",
+      "integrity": "sha512-RC0twEwwBKbhk/y4B2X4YEciRG1xoKMgiPy5xQqNMd3pG78sR+ybctG/m7c/8+NaaQOS22UPUCBd6yS6WihBIg==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@apollo/utils.isnodelike": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-1.1.0.tgz",
-      "integrity": "sha512-q/Q82kBUSEcx1ED11JO1TYBY781mWluUnBD8NvhjHVsu1K1C5R9BZVUxShyK/V8XcePcRUB5fdWOcBMGwS0KOA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.0.tgz",
+      "integrity": "sha512-77CiAM2qDXn0haQYrgX0UgrboQykb+bOHaz5p3KKItMwUZ/EFphzuB2vqHvubneIc9dxJcTx2L7MFDswRw/JAQ==",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       }
     },
     "node_modules/@apollo/utils.keyvaluecache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-1.0.1.tgz",
-      "integrity": "sha512-nLgYLomqjVimEzQ4cdvVQkcryi970NDvcRVPfd0OPeXhBfda38WjBq+WhQFk+czSHrmrSp34YHBxpat0EtiowA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.0.1.tgz",
+      "integrity": "sha512-F1v3m2pMXPD3rb2+F79qklBBFtNSWssV+8YJIAI0iLxRxoNdDAzfrBFUseUaBaeen/e5mR54QkeNCiq8EvQ/Eg==",
       "dependencies": {
-        "@apollo/utils.logger": "^1.0.0",
-        "lru-cache": "^7.10.1"
+        "@apollo/utils.logger": "^2.0.0",
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@apollo/utils.logger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.1.tgz",
-      "integrity": "sha512-XdlzoY7fYNK4OIcvMD2G94RoFZbzTQaNP0jozmqqMudmaGo2I/2Jx71xlDJ801mWA/mbYRihyaw6KJii7k5RVA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
+      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-1.1.0.tgz",
-      "integrity": "sha512-GfFSkAv3n1toDZ4V6u2d7L4xMwLA+lv+6hqXicMN9KELSJ9yy9RzuEXaX73c/Ry+GzRsBy/fdSUGayGqdHfT2Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.0.tgz",
+      "integrity": "sha512-S+wyxFyuO0LJ8v+mg8c7rRwyKZ+9xlO5wXD/UgaysH3rcCe9NBHRWx/9cmdZ9nTqgKC5X01uHZ6Gsi6pOrUGgw==",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/utils.removealiases": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-1.0.0.tgz",
-      "integrity": "sha512-6cM8sEOJW2LaGjL/0vHV0GtRaSekrPQR4DiywaApQlL9EdROASZU5PsQibe2MWeZCOhNrPRuHh4wDMwPsWTn8A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.0.tgz",
+      "integrity": "sha512-PT5ICz2SfrMCRsR3DhW2E1anX6hcqVXE/uHpmRHbhqSoQODZKG34AlFm1tC8u3MC3eK5gcvtpGvPHF/cwVfakg==",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/utils.sortast": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-1.1.0.tgz",
-      "integrity": "sha512-VPlTsmUnOwzPK5yGZENN069y6uUHgeiSlpEhRnLFYwYNoJHsuJq2vXVwIaSmts015WTPa2fpz1inkLYByeuRQA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.0.tgz",
+      "integrity": "sha512-VKoVOh8xkvh5HabtyGTekIYbwXdyYFPodFuHpWp333Fo2KBmpczLY+RBMHEr3v2MLoXDn/WUMtR3JZmvFJ45zw==",
       "dependencies": {
         "lodash.sortby": "^4.7.0"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/utils.stripsensitiveliterals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-1.2.0.tgz",
-      "integrity": "sha512-E41rDUzkz/cdikM5147d8nfCFVKovXxKBcjvLEQ7bjZm/cg9zEcXvS6vFY8ugTubI3fn6zoqo0CyU8zT+BGP9w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.0.tgz",
+      "integrity": "sha512-pzj1XINetE54uxIjc4bN6gVzDWYP8OZ/yB0xMTgvzttu1VLgXf3BTV76d9hlqLoe8cV0JiD+xLpJktrHOzmBJQ==",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/utils.usagereporting": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-1.0.1.tgz",
-      "integrity": "sha512-6dk+0hZlnDbahDBB2mP/PZ5ybrtCJdLMbeNJD+TJpKyZmSY6bA3SjI8Cr2EM9QA+AdziywuWg+SgbWUF3/zQqQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.0.0.tgz",
+      "integrity": "sha512-9VvVgA/LzKkBEYEGwE9doL1Sl+VRULkbB3D7W+ImJ028jJuTllvlQsh4Xpqz8mJWprfKx4m/i2DwHtElHWU2vg==",
       "dependencies": {
         "@apollo/usage-reporting-protobuf": "^4.0.0",
-        "@apollo/utils.dropunuseddefinitions": "^1.1.0",
-        "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
-        "@apollo/utils.removealiases": "1.0.0",
-        "@apollo/utils.sortast": "^1.1.0",
-        "@apollo/utils.stripsensitiveliterals": "^1.2.0"
+        "@apollo/utils.dropunuseddefinitions": "^2.0.0",
+        "@apollo/utils.printwithreducedwhitespace": "^2.0.0",
+        "@apollo/utils.removealiases": "2.0.0",
+        "@apollo/utils.sortast": "^2.0.0",
+        "@apollo/utils.stripsensitiveliterals": "^2.0.0"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/utils.withrequired": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-1.0.1.tgz",
-      "integrity": "sha512-5DYufeISXjz9UqtISIwte86F8ELjTrKVeXcPtdnUnV/PX+4EXUjqIp1FLJTYrCQ1a9OyFAMeCZ2QhUy1D8w7/A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.0.tgz",
+      "integrity": "sha512-+djpTu6AEE/A1etryZs9tmXRyDY6XXGe3G29MS/LB09uHq3pcl3n4Q5lvDTL5JWKuJixrulg5djePLDAooG8dQ==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -741,11 +750,22 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.3.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.12.tgz",
-      "integrity": "sha512-BFL8r4+FrqecPnIW0H8UJCBRQ4Y8Ep60aujw9c/sQuFmQTiqgWgpphswMGfaosP2zUinDE3ojU5wwcS2IJnumA==",
+      "version": "8.3.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.14.tgz",
+      "integrity": "sha512-zV0MU1DnxJLIB0wpL4N3u21agEiYFsjm6DI130jqHpwF0pR9HkF+Ni65BNfts4zQelP0GjkHltG+opaozAJ1NA==",
       "dependencies": {
-        "@graphql-tools/utils": "9.1.1",
+        "@graphql-tools/utils": "9.1.3",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
+      "integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+      "dependencies": {
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -761,6 +781,18 @@
         "@graphql-tools/utils": "9.1.1",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/merge": {
+      "version": "8.3.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.12.tgz",
+      "integrity": "sha512-BFL8r4+FrqecPnIW0H8UJCBRQ4Y8Ep60aujw9c/sQuFmQTiqgWgpphswMGfaosP2zUinDE3ojU5wwcS2IJnumA==",
+      "dependencies": {
+        "@graphql-tools/utils": "9.1.1",
+        "tslib": "^2.4.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -3965,9 +3997,9 @@
       }
     },
     "node_modules/mahudas": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/mahudas/-/mahudas-0.0.3.tgz",
-      "integrity": "sha512-WKJG9RQGixiypcQrFtSEsGA3SYkrfiraQdaB+f/NDRd89DFcJrAgEf/GmMSni4vdN+G4qFi0XEh+fK0RGuG1Ug==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mahudas/-/mahudas-0.0.7.tgz",
+      "integrity": "sha512-CZ7wIWtNpiZocL8if8SNVqmBCosW8+Plvv+ubRN3+BoiJh/+ZOuxcWrH9WpQkUUte5qNY+OyGkscBtch2Hdqcg==",
       "dependencies": {
         "cron": "^2.1.0",
         "dayjs": "^1.11.5",
@@ -3976,11 +4008,17 @@
         "koa-bodyparser": "^4.3.0",
         "koa-helmet": "^6.1.0",
         "koa-router": "^12.0.0",
-        "koa-static": "^5.0.0"
+        "koa-static": "^5.0.0",
+        "ms": "^2.1.3"
       },
       "bin": {
         "mahudas": "bin/launcher.js"
       }
+    },
+    "node_modules/mahudas/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -6013,20 +6051,20 @@
       }
     },
     "@apollo/server": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.1.1.tgz",
-      "integrity": "sha512-YD4LktN4s4biNP6CzJ6vl+NCeeoAX5mVpwfl1oyPHXRpjJpgitGmTlkbv3U/pzBweZd3rMEEz30hex/ezsYKpg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.2.2.tgz",
+      "integrity": "sha512-kcWnRy63KFrY1SxIVGX56wlMLRSgwmn2qR0IG0A7Mvrl6oXijVP5ETj7ulmwRcvvJsIoDOObhcCW5hW3UZy41Q==",
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/server-gateway-interface": "^1.0.5",
+        "@apollo/server-gateway-interface": "^1.0.7",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
-        "@apollo/utils.createhash": "^1.1.0",
-        "@apollo/utils.fetcher": "^1.0.0",
-        "@apollo/utils.isnodelike": "^1.1.0",
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "@apollo/utils.logger": "^1.0.0",
-        "@apollo/utils.usagereporting": "^1.0.0",
-        "@apollo/utils.withrequired": "^1.0.0",
+        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.fetcher": "^2.0.0",
+        "@apollo/utils.isnodelike": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.logger": "^2.0.0",
+        "@apollo/utils.usagereporting": "^2.0.0",
+        "@apollo/utils.withrequired": "^2.0.0",
         "@graphql-tools/schema": "^9.0.0",
         "@josephg/resolvable": "^1.0.0",
         "@types/express": "^4.17.13",
@@ -6046,14 +6084,14 @@
       }
     },
     "@apollo/server-gateway-interface": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.5.tgz",
-      "integrity": "sha512-sAu85MR82hdccGW08+QwXAGKRL3LpOnc0DNleTSDMkC9+Uv1f841HviKk8YaWYkXzbWIKzS7YDsNLYlHG8G+XQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.7.tgz",
+      "integrity": "sha512-Eas36z851D0B0Hw8Ihpig2thHcoVAcFE7/I0+DAOaXr70r8kajPq5QHhngqFrlSTVl4AlJ7Yw1SGaWdvuSmDPQ==",
       "requires": {
         "@apollo/usage-reporting-protobuf": "^4.0.0",
-        "@apollo/utils.fetcher": "^1.0.0",
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "@apollo/utils.logger": "^1.0.0"
+        "@apollo/utils.fetcher": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.logger": "^2.0.0"
       }
     },
     "@apollo/usage-reporting-protobuf": {
@@ -6065,87 +6103,87 @@
       }
     },
     "@apollo/utils.createhash": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-1.1.0.tgz",
-      "integrity": "sha512-5fT4ZiW75515OlikWpIQzaVDws1yy9VgYSoHoJCrvI2UH6/7YNKXQjbjT5qVYu6ytch2wBxFMfFfYWMn/2bSCQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.0.tgz",
+      "integrity": "sha512-9GhGGD3J0HJF/VC+odwYpKi3Cg1NWrsO8GQvyGwDS5v/78I3154Hn8s4tpW+nqoaQ/lAvxdQQr3HM1b5HLM6Ww==",
       "requires": {
-        "@apollo/utils.isnodelike": "^1.1.0",
+        "@apollo/utils.isnodelike": "^2.0.0",
         "sha.js": "^2.4.11"
       }
     },
     "@apollo/utils.dropunuseddefinitions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz",
-      "integrity": "sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.0.tgz",
+      "integrity": "sha512-BoPW+Z3kA8kLh0FCWyzOt+R77W5mVZWer5s6UyvVwZ/qROGiEgcHXFcI5TMMndpXoDo0xBSvQV0lIKYHbJQ7+g==",
       "requires": {}
     },
     "@apollo/utils.fetcher": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-1.1.1.tgz",
-      "integrity": "sha512-0vXVznO7kw5VWwxyV5wsDvYEwjDpyZ7vYQAXCseLXqBn2eWEIDViM7qRzi/Hnv4zzAQ05phdimSED99K+lg+SQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.0.tgz",
+      "integrity": "sha512-RC0twEwwBKbhk/y4B2X4YEciRG1xoKMgiPy5xQqNMd3pG78sR+ybctG/m7c/8+NaaQOS22UPUCBd6yS6WihBIg=="
     },
     "@apollo/utils.isnodelike": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-1.1.0.tgz",
-      "integrity": "sha512-q/Q82kBUSEcx1ED11JO1TYBY781mWluUnBD8NvhjHVsu1K1C5R9BZVUxShyK/V8XcePcRUB5fdWOcBMGwS0KOA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.0.tgz",
+      "integrity": "sha512-77CiAM2qDXn0haQYrgX0UgrboQykb+bOHaz5p3KKItMwUZ/EFphzuB2vqHvubneIc9dxJcTx2L7MFDswRw/JAQ=="
     },
     "@apollo/utils.keyvaluecache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-1.0.1.tgz",
-      "integrity": "sha512-nLgYLomqjVimEzQ4cdvVQkcryi970NDvcRVPfd0OPeXhBfda38WjBq+WhQFk+czSHrmrSp34YHBxpat0EtiowA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.0.1.tgz",
+      "integrity": "sha512-F1v3m2pMXPD3rb2+F79qklBBFtNSWssV+8YJIAI0iLxRxoNdDAzfrBFUseUaBaeen/e5mR54QkeNCiq8EvQ/Eg==",
       "requires": {
-        "@apollo/utils.logger": "^1.0.0",
-        "lru-cache": "^7.10.1"
+        "@apollo/utils.logger": "^2.0.0",
+        "lru-cache": "^7.14.1"
       }
     },
     "@apollo/utils.logger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.1.tgz",
-      "integrity": "sha512-XdlzoY7fYNK4OIcvMD2G94RoFZbzTQaNP0jozmqqMudmaGo2I/2Jx71xlDJ801mWA/mbYRihyaw6KJii7k5RVA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
+      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
     },
     "@apollo/utils.printwithreducedwhitespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-1.1.0.tgz",
-      "integrity": "sha512-GfFSkAv3n1toDZ4V6u2d7L4xMwLA+lv+6hqXicMN9KELSJ9yy9RzuEXaX73c/Ry+GzRsBy/fdSUGayGqdHfT2Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.0.tgz",
+      "integrity": "sha512-S+wyxFyuO0LJ8v+mg8c7rRwyKZ+9xlO5wXD/UgaysH3rcCe9NBHRWx/9cmdZ9nTqgKC5X01uHZ6Gsi6pOrUGgw==",
       "requires": {}
     },
     "@apollo/utils.removealiases": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-1.0.0.tgz",
-      "integrity": "sha512-6cM8sEOJW2LaGjL/0vHV0GtRaSekrPQR4DiywaApQlL9EdROASZU5PsQibe2MWeZCOhNrPRuHh4wDMwPsWTn8A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.0.tgz",
+      "integrity": "sha512-PT5ICz2SfrMCRsR3DhW2E1anX6hcqVXE/uHpmRHbhqSoQODZKG34AlFm1tC8u3MC3eK5gcvtpGvPHF/cwVfakg==",
       "requires": {}
     },
     "@apollo/utils.sortast": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-1.1.0.tgz",
-      "integrity": "sha512-VPlTsmUnOwzPK5yGZENN069y6uUHgeiSlpEhRnLFYwYNoJHsuJq2vXVwIaSmts015WTPa2fpz1inkLYByeuRQA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.0.tgz",
+      "integrity": "sha512-VKoVOh8xkvh5HabtyGTekIYbwXdyYFPodFuHpWp333Fo2KBmpczLY+RBMHEr3v2MLoXDn/WUMtR3JZmvFJ45zw==",
       "requires": {
         "lodash.sortby": "^4.7.0"
       }
     },
     "@apollo/utils.stripsensitiveliterals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-1.2.0.tgz",
-      "integrity": "sha512-E41rDUzkz/cdikM5147d8nfCFVKovXxKBcjvLEQ7bjZm/cg9zEcXvS6vFY8ugTubI3fn6zoqo0CyU8zT+BGP9w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.0.tgz",
+      "integrity": "sha512-pzj1XINetE54uxIjc4bN6gVzDWYP8OZ/yB0xMTgvzttu1VLgXf3BTV76d9hlqLoe8cV0JiD+xLpJktrHOzmBJQ==",
       "requires": {}
     },
     "@apollo/utils.usagereporting": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-1.0.1.tgz",
-      "integrity": "sha512-6dk+0hZlnDbahDBB2mP/PZ5ybrtCJdLMbeNJD+TJpKyZmSY6bA3SjI8Cr2EM9QA+AdziywuWg+SgbWUF3/zQqQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.0.0.tgz",
+      "integrity": "sha512-9VvVgA/LzKkBEYEGwE9doL1Sl+VRULkbB3D7W+ImJ028jJuTllvlQsh4Xpqz8mJWprfKx4m/i2DwHtElHWU2vg==",
       "requires": {
         "@apollo/usage-reporting-protobuf": "^4.0.0",
-        "@apollo/utils.dropunuseddefinitions": "^1.1.0",
-        "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
-        "@apollo/utils.removealiases": "1.0.0",
-        "@apollo/utils.sortast": "^1.1.0",
-        "@apollo/utils.stripsensitiveliterals": "^1.2.0"
+        "@apollo/utils.dropunuseddefinitions": "^2.0.0",
+        "@apollo/utils.printwithreducedwhitespace": "^2.0.0",
+        "@apollo/utils.removealiases": "2.0.0",
+        "@apollo/utils.sortast": "^2.0.0",
+        "@apollo/utils.stripsensitiveliterals": "^2.0.0"
       }
     },
     "@apollo/utils.withrequired": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-1.0.1.tgz",
-      "integrity": "sha512-5DYufeISXjz9UqtISIwte86F8ELjTrKVeXcPtdnUnV/PX+4EXUjqIp1FLJTYrCQ1a9OyFAMeCZ2QhUy1D8w7/A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.0.tgz",
+      "integrity": "sha512-+djpTu6AEE/A1etryZs9tmXRyDY6XXGe3G29MS/LB09uHq3pcl3n4Q5lvDTL5JWKuJixrulg5djePLDAooG8dQ=="
     },
     "@babel/code-frame": {
       "version": "7.18.6",
@@ -6518,12 +6556,22 @@
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.3.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.12.tgz",
-      "integrity": "sha512-BFL8r4+FrqecPnIW0H8UJCBRQ4Y8Ep60aujw9c/sQuFmQTiqgWgpphswMGfaosP2zUinDE3ojU5wwcS2IJnumA==",
+      "version": "8.3.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.14.tgz",
+      "integrity": "sha512-zV0MU1DnxJLIB0wpL4N3u21agEiYFsjm6DI130jqHpwF0pR9HkF+Ni65BNfts4zQelP0GjkHltG+opaozAJ1NA==",
       "requires": {
-        "@graphql-tools/utils": "9.1.1",
+        "@graphql-tools/utils": "9.1.3",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "9.1.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
+          "integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@graphql-tools/schema": {
@@ -6535,6 +6583,17 @@
         "@graphql-tools/utils": "9.1.1",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "@graphql-tools/merge": {
+          "version": "8.3.12",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.12.tgz",
+          "integrity": "sha512-BFL8r4+FrqecPnIW0H8UJCBRQ4Y8Ep60aujw9c/sQuFmQTiqgWgpphswMGfaosP2zUinDE3ojU5wwcS2IJnumA==",
+          "requires": {
+            "@graphql-tools/utils": "9.1.1",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@graphql-tools/utils": {
@@ -8959,9 +9018,9 @@
       "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
     },
     "mahudas": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/mahudas/-/mahudas-0.0.3.tgz",
-      "integrity": "sha512-WKJG9RQGixiypcQrFtSEsGA3SYkrfiraQdaB+f/NDRd89DFcJrAgEf/GmMSni4vdN+G4qFi0XEh+fK0RGuG1Ug==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mahudas/-/mahudas-0.0.7.tgz",
+      "integrity": "sha512-CZ7wIWtNpiZocL8if8SNVqmBCosW8+Plvv+ubRN3+BoiJh/+ZOuxcWrH9WpQkUUte5qNY+OyGkscBtch2Hdqcg==",
       "requires": {
         "cron": "^2.1.0",
         "dayjs": "^1.11.5",
@@ -8970,7 +9029,15 @@
         "koa-bodyparser": "^4.3.0",
         "koa-helmet": "^6.1.0",
         "koa-router": "^12.0.0",
-        "koa-static": "^5.0.0"
+        "koa-static": "^5.0.0",
+        "ms": "^2.1.3"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
     "make-dir": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mahudas/apollo4",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Apollo v4 plugin for Mahudas.",
   "main": "app.js",
   "scripts": {
@@ -16,11 +16,11 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@apollo/server": "^4.1.1",
+    "@apollo/server": "^4.2.2",
     "@graphql-tools/load-files": "^6.6.1",
-    "@graphql-tools/merge": "^8.3.12",
+    "@graphql-tools/merge": "^8.3.14",
     "dataloader": "^2.1.0",
-    "mahudas": "^0.0.3"
+    "mahudas": "^0.0.7"
   },
   "devDependencies": {
     "eslint": "^8.26.0",


### PR DESCRIPTION
在載入typeDefs與resolvers時，先判斷config裡設定的路徑是否存在，
若是不存在的話，就加上app.appInfo.root當根目錄，用來解決Mahudas的根目錄與process.cwd()是在不同目錄之下的問題。

順便更新dependencies的版本。

issue #1